### PR TITLE
Add support for reading gzipped input FASTQs and writing to stdout

### DIFF
--- a/pychopper/__init__.py
+++ b/pychopper/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = 'ONT Applications Group'
 __email__ = 'Apps@nanoporetech.com'
-__version__ = '2.5.0'
+__version__ = '2.6.0'

--- a/pychopper/utils.py
+++ b/pychopper/utils.py
@@ -50,8 +50,8 @@ def hit2bed(hit, read):
     return bed_line
 
 
-def count_fastq_records(fname, size=128000000):
-    fh = open(fname, "r")
+def count_fastq_records(fname, size=128000000, opener=open):
+    fh = opener(fname, "r")
     count = 0
     while True:
         b = fh.read(size)

--- a/scripts/cdna_classifier.py
+++ b/scripts/cdna_classifier.py
@@ -68,7 +68,7 @@ parser.add_argument(
 parser.add_argument(
     '-D', metavar='read stats', type=str, default=None, help="Tab separated file with per-read stats (None).")
 parser.add_argument('input_fastx', metavar='input_fastx', type=str, help="Input file.")
-parser.add_argument('output_fastx', metavar='output_fastx', type=str, help="Output file.")
+parser.add_argument('output_fastx', metavar='output_fastx', nargs="?", type=str, default="-", help="Output file.")
 
 
 def _new_stats():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.5.0
+current_version = 2.6.0
 commit = True
 tag = True
 
@@ -19,4 +19,3 @@ exclude = docs
 
 [aliases]
 test = pytest
-

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [
 
 setup(
     name='pychopper',
-    version='2.5.0',
+    version='2.6.0',
     description="A tool to identify full length cDNA reads.",
     long_description=readme,
     author="ONT Applications Group",


### PR DESCRIPTION
*Changelog:*
- Add gzip reading support (Issue #53)
- Make option to write to stdout explicit (skipping output file will write to stdout)